### PR TITLE
<improve> address latency issues

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,8 @@
 ## Customize dependencies
 dependencies:
   pre:
-    - curl -o $HOME/google_appengine_1.9.18.zip https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.18.zip
-    - unzip -q -d $HOME $HOME/google_appengine_1.9.18.zip
+    - curl -o $HOME/google_appengine_1.9.19.zip https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.19.zip
+    - unzip -q -d $HOME $HOME/google_appengine_1.9.19.zip
 
 machine:
   environment:

--- a/functional_tests/test_groups.py
+++ b/functional_tests/test_groups.py
@@ -40,7 +40,7 @@ class DiscourseGroupTestCase(unittest.TestCase):
 
         self.assertTrue(response['basic_group'] is not None)
 
-    def testAddUserToGroup(self):
+    def testAddUserToGroupByEmail(self):
         discourse_client.groups.create(
             group_name='quarterbacks'
         ).get_result()
@@ -52,14 +52,14 @@ class DiscourseGroupTestCase(unittest.TestCase):
             username='peyton18'
         ).get_result()
 
-        response = discourse_client.groups.addUser(
+        response = discourse_client.groups.addUserByEmail(
             user_email='peyton@example.com',
             group_name='quarterbacks'
         ).get_result()
 
         self.assertEqual('OK', response['success'])
 
-    def testRemoveUserFromGroup(self):
+    def testRemoveUserFromGroupByEmail(self):
         discourse_client.groups.create(
             group_name='quarterbacks'
         ).get_result()
@@ -71,12 +71,12 @@ class DiscourseGroupTestCase(unittest.TestCase):
             username='peyton18'
         ).get_result()
 
-        discourse_client.groups.addUser(
+        discourse_client.groups.addUserByEmail(
             user_email='peyton@example.com',
             group_name='quarterbacks'
         ).get_result()
 
-        response = discourse_client.groups.removeUser(
+        response = discourse_client.groups.removeUserByEmail(
             user_email='peyton@example.com',
             group_name='quarterbacks'
         ).get_result()

--- a/functional_tests/test_groups.py
+++ b/functional_tests/test_groups.py
@@ -71,13 +71,56 @@ class DiscourseGroupTestCase(unittest.TestCase):
             username='peyton18'
         ).get_result()
 
-        discourse_client.groups.addUserByEmail(
-            user_email='peyton@example.com',
+        discourse_client.groups.addUserByUsername(
+            username='peyton18',
             group_name='quarterbacks'
         ).get_result()
 
         response = discourse_client.groups.removeUserByEmail(
             user_email='peyton@example.com',
+            group_name='quarterbacks'
+        ).get_result()
+
+        self.assertEqual('OK', response['success'])
+
+    def testAddUserToGroupByUsername(self):
+        discourse_client.groups.create(
+            group_name='quarterbacks'
+        ).get_result()
+
+        discourse_client.users.create(
+            name='John Elway',
+            email='john@example.com',
+            password='go card',
+            username='jelway7'
+        ).get_result()
+
+        response = discourse_client.groups.addUserByUsername(
+            username='jelway7',
+            group_name='quarterbacks'
+        ).get_result()
+
+        self.assertEqual('OK', response['success'])
+
+    def testRemoveUserFromGroupByUsername(self):
+        discourse_client.groups.create(
+            group_name='quarterbacks'
+        ).get_result()
+
+        discourse_client.users.create(
+            name='Peyton Manning',
+            email='peyton@example.com',
+            password='omaha, omaha',
+            username='peyton18'
+        ).get_result()
+
+        discourse_client.groups.addUserByUsername(
+            username='peyton18',
+            group_name='quarterbacks'
+        ).get_result()
+
+        response = discourse_client.groups.removeUserByUsername(
+            username='peyton18',
             group_name='quarterbacks'
         ).get_result()
 

--- a/gae_discourse_client/groups.py
+++ b/gae_discourse_client/groups.py
@@ -19,7 +19,7 @@ class GroupClient(object):
         self._user_client = user_client
 
     @ndb.tasklet
-    def addUser(self, user_email, group_name):
+    def addUserByEmail(self, user_email, group_name):
         """Adds the given account to the Discourse group with the given name
 
         Args:
@@ -52,7 +52,7 @@ class GroupClient(object):
         raise ndb.Return(result)
 
     @ndb.tasklet
-    def removeUser(self, user_email, group_name):
+    def removeUserByEmail(self, user_email, group_name):
         """Removes an account from a group
 
         Args:

--- a/gae_discourse_client/users.py
+++ b/gae_discourse_client/users.py
@@ -21,8 +21,31 @@ class UserClient(object):
     # USER ACTIONS
 
     @ndb.tasklet
+    def getByUsername(self, username):
+        """Finds the Discourse user with the given username.
+
+        Args:
+          username: The username of the user to find.
+
+        Returns:
+          A dictionary containing information about the user if the user is successfully found,
+          None otherwise.
+        """
+        user = yield self._api_client.getRequest(
+            'users/%s.json' % username
+        )
+
+        if user:
+            raise ndb.Return(user['user'])
+        else:
+            raise ndb.Return(None)
+
+    @ndb.tasklet
     def getByEmail(self, user_email):
         """Finds the Discourse user with the given email.
+
+        Note that this is significantly slower than getByUsername, since Discourse users are
+        indexed on username but not on email.
 
         Args:
           user_email: The email address of the user to find.

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -52,7 +52,7 @@ class DiscourseUserUnitTestCase(base.TestCase):
 
         discourse_client.groups.delete('quarterbacks').get_result()
 
-    def testAddUserToGroup(self):
+    def testAddUserToGroupByEmail(self):
         response = self.mock()
         response.status_code = 200
         response.content = json.dumps([{'email': 'peyton18@example.com', 'id': 18, 'username': 'peyton18'}])
@@ -69,7 +69,7 @@ class DiscourseUserUnitTestCase(base.TestCase):
         payload = urlencode({'usernames': 'peyton18'})
         self._expectUrlfetch(url='http://rants.example.com/admin/groups/32/members.json', method='PUT', payload=payload, response=response)
 
-        discourse_client.groups.addUser('peyton18@example.com', 'quarterbacks').get_result()
+        discourse_client.groups.addUserByEmail('peyton18@example.com', 'quarterbacks').get_result()
 
     def testAddUserFailsWhenUserNotFound(self):
         response = self.mock()
@@ -78,7 +78,7 @@ class DiscourseUserUnitTestCase(base.TestCase):
         self._expectUrlfetch(url='http://rants.example.com/admin/users/list/active.json?filter=peyton18%40example.com&show_emails=true', method='GET', payload='', response=response)
 
         with self.assertRaises(discourse_client.Error):
-            discourse_client.groups.addUser('peyton18@example.com', 'quarterbacks').get_result()
+            discourse_client.groups.addUserByEmail('peyton18@example.com', 'quarterbacks').get_result()
 
     def testAddUserFailsWhenGroupNotFound(self):
         response = self.mock()
@@ -92,9 +92,9 @@ class DiscourseUserUnitTestCase(base.TestCase):
         self._expectUrlfetch(url='http://rants.example.com/admin/groups.json', method='GET', payload='', response=response)
 
         with self.assertRaises(discourse_client.Error):
-            discourse_client.groups.addUser('peyton18@example.com', 'quarterbacks').get_result()
+            discourse_client.groups.addUserByEmail('peyton18@example.com', 'quarterbacks').get_result()
 
-    def testRemoveUserFromGroup(self):
+    def testRemoveUserFromGroupByEmail(self):
         response = self.mock()
         response.status_code = 200
         response.content = json.dumps([{'email': 'peyton18@example.com', 'id': 18, 'username': 'peyton18'}])
@@ -110,4 +110,4 @@ class DiscourseUserUnitTestCase(base.TestCase):
         response.content = json.dumps({'success': True})
         self._expectUrlfetch(url='http://rants.example.com/admin/groups/32/members.json?user_id=18', method='DELETE', payload='', response=response)
 
-        discourse_client.groups.removeUser('peyton18@example.com', 'quarterbacks').get_result()
+        discourse_client.groups.removeUserByEmail('peyton18@example.com', 'quarterbacks').get_result()

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -71,6 +71,20 @@ class DiscourseUserUnitTestCase(base.TestCase):
 
         discourse_client.groups.addUserByEmail('peyton18@example.com', 'quarterbacks').get_result()
 
+    def testAddUserToGroupByUsername(self):
+        response = self.mock()
+        response.status_code = 200
+        response.content = json.dumps([{'name': 'quarterbacks', 'id': 32}])
+        self._expectUrlfetch(url='http://rants.example.com/admin/groups.json', method='GET', payload='', response=response)
+
+        response = self.mock()
+        response.status_code = 200
+        response.content = json.dumps({'success': True})
+        payload = urlencode({'usernames': 'peyton18'})
+        self._expectUrlfetch(url='http://rants.example.com/admin/groups/32/members.json', method='PUT', payload=payload, response=response)
+
+        discourse_client.groups.addUserByUsername('peyton18', 'quarterbacks').get_result()
+
     def testAddUserFailsWhenUserNotFound(self):
         response = self.mock()
         response.status_code = 404
@@ -111,3 +125,21 @@ class DiscourseUserUnitTestCase(base.TestCase):
         self._expectUrlfetch(url='http://rants.example.com/admin/groups/32/members.json?user_id=18', method='DELETE', payload='', response=response)
 
         discourse_client.groups.removeUserByEmail('peyton18@example.com', 'quarterbacks').get_result()
+
+    def testRemoveUserFromGroupByUsername(self):
+        response = self.mock()
+        response.status_code = 200
+        response.content = json.dumps({'user': {'email': 'peyton18@example.com', 'id': 18, 'username': 'peyton18'}})
+        self._expectUrlfetch(url='http://rants.example.com/users/peyton18.json', method='GET', payload='', response=response)
+
+        response = self.mock()
+        response.status_code = 200
+        response.content = json.dumps([{'name': 'quarterbacks', 'id': 32}])
+        self._expectUrlfetch(url='http://rants.example.com/admin/groups.json', method='GET', payload='', response=response)
+
+        response = self.mock()
+        response.status_code = 200
+        response.content = json.dumps({'success': True})
+        self._expectUrlfetch(url='http://rants.example.com/admin/groups/32/members.json?user_id=18', method='DELETE', payload='', response=response)
+
+        discourse_client.groups.removeUserByUsername('peyton18', 'quarterbacks').get_result()


### PR DESCRIPTION
Reviewer: @ods94065

These are the changes I think I need in the GAE Discourse client to fix the slowness issues we're seeing on our end. Essentially, looking up users based on username is the only efficient way to find them -- the table `single_sign_on_records` is indexed by external ID, but to get the user from that, Discourse has to search through all users to find the one with that SSO record. It doesn't seem efficient and I'd love to look into helping them by making that better, but for now this will have to do.

We don't always have access to the username, but most of our problems happen right after we create the user when we try to add them to the group, and we do then (since we create a username for them to use) so for now that's the area that I'm going to work with.
