### PR TITLE
<improve> get user info from admin view

### DIFF
--- a/gae_discourse_client/users.py
+++ b/gae_discourse_client/users.py
@@ -32,11 +32,11 @@ class UserClient(object):
           None otherwise.
         """
         user = yield self._api_client.getRequest(
-            'users/%s.json' % username
+            'admin/users/%s.json' % username
         )
 
         if user:
-            raise ndb.Return(user['user'])
+            raise ndb.Return(user)
         else:
             raise ndb.Return(None)
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -129,8 +129,8 @@ class DiscourseUserUnitTestCase(base.TestCase):
     def testRemoveUserFromGroupByUsername(self):
         response = self.mock()
         response.status_code = 200
-        response.content = json.dumps({'user': {'email': 'peyton18@example.com', 'id': 18, 'username': 'peyton18'}})
-        self._expectUrlfetch(url='http://rants.example.com/users/peyton18.json', method='GET', payload='', response=response)
+        response.content = json.dumps({'email': 'peyton18@example.com', 'id': 18, 'username': 'peyton18'})
+        self._expectUrlfetch(url='http://rants.example.com/admin/users/peyton18.json', method='GET', payload='', response=response)
 
         response = self.mock()
         response.status_code = 200


### PR DESCRIPTION
This gets user info from the admin view, rather than the normal view. It gives us a little more info about the user, including SSO information.

To see the difference, compare http://discussions.udacity.com/admin/users/thomasatudacity.json with the `user` field of http://discussions.udacity.com/users/thomasatudacity.json.
